### PR TITLE
Pixelated effect for audio spectrum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amethyst",
-  "version": "1.3.0",
+  "version": "1.3.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "amethyst",
-      "version": "1.3.0",
+      "version": "1.3.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/renderer/components/Spectrum.vue
+++ b/src/renderer/components/Spectrum.vue
@@ -4,6 +4,7 @@ import { onMounted, onUnmounted } from "vue";
 const props = defineProps<{ node: MediaElementAudioSourceNode }>();
 const SPECTRUM_WIDTH = 500;
 const SPECTRUM_HEIGHT = 150;
+const DOWNSCALE_FAC = 7;
 const TILT_MULTIPLIER = 0.005; // 3dB/octave
 const FFT_SIZE = 8192;
 const VERTICAL_ZOOM_FACTOR = 1.5;
@@ -51,6 +52,7 @@ onMounted(() => {
 
 		if (canvas) {
 			canvas.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--color-spectrum-peaks");
+			canvas.imageSmoothingEnabled = false;
 			return canvas;
 		}
 		return canvas;
@@ -74,6 +76,12 @@ onMounted(() => {
 			canvasCtx.value?.fillRect(i * barWidth, SPECTRUM_HEIGHT - barHeight, 1, barHeight);
 		}
 
+		canvasCtx.value?.drawImage(spectrum, 0, 0, SPECTRUM_WIDTH / DOWNSCALE_FAC, SPECTRUM_HEIGHT / DOWNSCALE_FAC);
+		canvasCtx.value?.clearRect(0, SPECTRUM_HEIGHT / DOWNSCALE_FAC, SPECTRUM_WIDTH, SPECTRUM_HEIGHT - (SPECTRUM_HEIGHT / DOWNSCALE_FAC))
+		canvasCtx.value?.clearRect(SPECTRUM_WIDTH / DOWNSCALE_FAC, 0, SPECTRUM_WIDTH, SPECTRUM_HEIGHT / DOWNSCALE_FAC);
+		canvasCtx.value?.drawImage(spectrum, 0, 0, SPECTRUM_WIDTH / DOWNSCALE_FAC, SPECTRUM_HEIGHT / DOWNSCALE_FAC, 0, 0, SPECTRUM_WIDTH, SPECTRUM_HEIGHT);
+		canvasCtx.value?.clearRect(0, 0, SPECTRUM_WIDTH / DOWNSCALE_FAC, SPECTRUM_HEIGHT / DOWNSCALE_FAC);
+
 		!shouldFuckOff && requestAnimationFrame(draw);
 	}
 
@@ -86,6 +94,7 @@ onUnmounted(() => shouldFuckOff = true);
 <template>
   <div class="w-min flex bg-spectrum-background flex-col">
     <canvas
+	  style="image-rendering: pixelated;"
       id="spectrum"
       ref="spectrum"
       :width="SPECTRUM_WIDTH"

--- a/src/renderer/components/Spectrum.vue
+++ b/src/renderer/components/Spectrum.vue
@@ -94,7 +94,6 @@ onUnmounted(() => shouldFuckOff = true);
 <template>
   <div class="w-min flex bg-spectrum-background flex-col">
     <canvas
-	  style="image-rendering: pixelated;"
       id="spectrum"
       ref="spectrum"
       :width="SPECTRUM_WIDTH"


### PR DESCRIPTION
Hi, I've added a simple pixilation filter for the audio spectrum to match the aesthetic with the rest of the app. It's currently implemented in a pretty bad way but whoever wants to can fix it (I guess it's an electron app anyway so performance isn't the biggest priority)

Here's an image: 
![image](https://user-images.githubusercontent.com/24507488/174499244-3fbbd5df-720b-4665-88b7-b83e727ef793.png)
